### PR TITLE
Can't update null values

### DIFF
--- a/src/Eloquent/Model.js
+++ b/src/Eloquent/Model.js
@@ -305,7 +305,10 @@ export default class Model {
             if (
                 typeof this.original[prop] !== 'undefined'
                 &&
-                this.original[prop].valueOf() === attributes[prop].valueOf()
+                (
+                    (this.original[prop] === null && attributes[prop] === null) 
+                    || (this.original[prop] !== null && attributes[prop] !== null && this.original[prop].valueOf() === attributes[prop].valueOf())
+                )
             ) {
                 delete attributes[prop];
             }


### PR DESCRIPTION
If a Value in this.original[prop] or in attributes[prop] was null there was an Error.

No Method .valueOf in null

fixed this.